### PR TITLE
Update link to R4IA on Amazon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
     <div id='page'>
       <div id="header">
         <p>Hi there, my parents and friends call me Ryan Bigg, but you may know me as "Radar". Either is fine.</p>
-        <p>I'm a technical writer for Ruby / Rails based in Australia. I have written a Rails book with <a href="https://github.com/sevenseacat">Rebecca Skinner</a> called <a href="http://manning.com/bigg2">Rails 4 in Action</a>, which is available also on <a href='http://www.amazon.com/Rails-3-Action-Ryan-Bigg/dp/1935182277'>Amazon</a>. I wrote <a href='http://leanpub.com/multi-tenancy-rails'>Multitenancy With Rails</a>, and I'm in the process of writing my third book <a href='http://leanpub.com/debuggingruby'>Debugging Ruby</a>.
+        <p>I'm a technical writer for Ruby / Rails based in Australia. I have written a Rails book with <a href="https://github.com/sevenseacat">Rebecca Skinner</a> called <a href="https://www.manning.com/books/rails-4-in-action">Rails 4 in Action</a>, which is available also on <a href='http://www.amazon.com/Rails-4-Action-Ryan-Bigg/dp/1617291099'>Amazon</a>. I wrote <a href='http://leanpub.com/multi-tenancy-rails'>Multitenancy With Rails</a>, and I'm in the process of writing my third book <a href='http://leanpub.com/debuggingruby'>Debugging Ruby</a>.
         </p>
 
         <div id="more">


### PR DESCRIPTION
Also included the final Manning URL, even though the old URL redirected there anyway.