### PR TITLE
Fix missing </p> in 2020-02-02 ROM part 2

### DIFF
--- a/_posts/2020-02-02-rom-and-dry-showcase-part-2.markdown
+++ b/_posts/2020-02-02-rom-and-dry-showcase-part-2.markdown
@@ -266,6 +266,7 @@ This code is a bit longer than the code we had previously. However, it comes wit
 
   <p>
     A much better approach is a call method that delegates to <em>other</em> methods.
+  </p>
 </aside>
 
 The `call` method here is responsible for ordering the steps of our transaction. It takes our initial `input` for this transaction and runs it through the validator. All of that validation logic is neatly gathered together in the `validate` method:


### PR DESCRIPTION
The page on https://ryanbigg.com/2020/02/rom-and-dry-showcase-part-2 was broken from this point, with the remainder rendered 
unformatted within the `<aside>`.

Hopefully this fixes that, although I haven't tested locally.

Thanks for the blog post!